### PR TITLE
chore: fix dead links

### DIFF
--- a/docs/quickstart/your-first-app.md
+++ b/docs/quickstart/your-first-app.md
@@ -11,7 +11,7 @@ We support [several proving schemes](../reference/supported-proving-schemes.md):
 |----------------|----------|---------------------------------------------------|---|---|
 | [Noir](https://noir-lang.org/docs/)     | noir     | Verification key. | Noir | |
 | [Risc0](https://risc0.com/docs/)    | risc0    | Image ID without a prefix. ex. 0x123 becomes 123. | Rust | [Template](https://github.com/hyli-org/template-risc0)|
-| [SP1](https://docs.succinct.xyz/docs/introduction)        | sp1   | Verification key.       | Rust | [Template](https://github.com/hyli-org/template-sp1)|
+| [SP1](https://docs.succinct.xyz/docs/sp1/introduction)        | sp1   | Verification key.       | Rust | [Template](https://github.com/hyli-org/template-sp1)|
 
 Clone the template or, for proving schemes without templates, use the templates as inspiration for writing your contract. You can also check our [app concept page](../concepts/apps.md.md) for more information!
 

--- a/docs/resources/release-notes.md
+++ b/docs/resources/release-notes.md
@@ -172,7 +172,7 @@ Read the [full changelog on GitHub](https://github.com/hyli-org/hyli/releases/ta
 
 ✨ New features:
 
-- Added [the SP1 prover](https://docs.succinct.xyz/docs/introduction) to the client SDK.
+- Added [the SP1 prover](https://docs.succinct.xyz/docs/network/introduction) to the client SDK.
 
 🚅 Improvements:
 


### PR DESCRIPTION
Hi, I fixed broken links in the documentation and replaced them with working ones.

`docs/quickstart/your-first-app.md `
https://docs.succinct.xyz/docs/introduction - old link
https://docs.succinct.xyz/docs/sp1/introduction - new link

`docs/resources/release-notes.md`
https://docs.succinct.xyz/docs/introduction - old link
https://docs.succinct.xyz/docs/network/introduction - new link